### PR TITLE
fix "no such file or directory" error

### DIFF
--- a/lib/renovate-encrypt.js
+++ b/lib/renovate-encrypt.js
@@ -17,7 +17,7 @@ process.stdin.on('readable', () => {
 
 process.stdin.on('end', async () => {
   const publicKey = fs.readFileSync(
-    path.resolve('public-keys/renovateapp-public.pem'),
+    path.resolve(__dirname, '../', 'public-keys/renovateapp-public.pem'),
     'utf8'
   );
   const buffer = new Buffer(stdin);


### PR DESCRIPTION
The path to the pem file was erroneously resolving to the project root, instead of the node_module. It was throwing the following error:
```
(node:13363) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, open '~/Sites/my-site/public-keys/renovateapp-public.pem'
```

I have updated the path to resolve to use `__dirname` so it resolves correctly.